### PR TITLE
Update IRIs in the ontology making the class index generation work

### DIFF
--- a/.github/workflows/cd_update_pages.yml
+++ b/.github/workflows/cd_update_pages.yml
@@ -68,9 +68,9 @@ jobs:
         run: |
           ontodoc \
             --iri-regex=https://w3id.org/emmo/domain/nanoindentation \
-            nanoindentation.ttl \
+            public/nanoindentation-inferred.ttl \
             build/nanoindentation.rst
-          cp README.md build/
+          cp -f README.md build/
           sphinx-build "build/" "public/"
 
       - name: Publish on GitHub Pages

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ The Nanoindentation Testing ontology is built with an alignment with CHAMEO and 
 
 
 ## Resources
-- Pre-inferred ontology: https://emmo-repo.github.io/domain-nanoindentation/nanoindentation-inferred.ttl
-- [Class index](https://emmo-repo.github.io/domain-nanoindentation/nanoindentation.html)
+- Squashed ontology (all imported ontologies included in the same turtle file for fast and robust loading):
+[https://w3id.org/emmo/domain/nanoindentation/](https://w3id.org/emmo/domain/nanoindentation/turtle)
+- Pre-inferred ontology: https://w3id.org/emmo/domain/nanoindentation/inferred
+- [Class index](https://w3id.org/emmo/domain/nanoindentation/)
 
 
 ## Attribution and Credits

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ The Nanoindentation Testing ontology is built with an alignment with CHAMEO and 
 | CHAMEO              | 1.0.0-beta5       |
 
 
+## Resources
+- Pre-inferred ontology: https://emmo-repo.github.io/domain-nanoindentation/nanoindentation-inferred.ttl
+- [Class index](https://emmo-repo.github.io/domain-nanoindentation/nanoindentation.html)
+
+
 ## Attribution and Credits
 
 ### Authors

--- a/nanoindentation.ttl
+++ b/nanoindentation.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#> .
+@prefix : <https://w3id.org/emmo/domain/nanoindentation#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -7,9 +7,10 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix chameo: <https://w3id.org/emmo/domain/characterisation-methodology/chameo#> .
-@base <https://w3id.org/emmo/domain/domain-nanoindentation/nanoindentation#> .
+@base <https://w3id.org/emmo/domain/nanoindentation#> .
 
-<http://emmo.info/emmo/domain/nanoind> rdf:type owl:Ontology ;
+<https://w3id.org/emmo/domain/nanoindentation> rdf:type owl:Ontology ;
+                                        owl:versionIRI <https://w3id.org/emmo/domain/1.0.0-alpha1/nanoindentation> ;
                                         owl:imports <https://w3id.org/emmo/domain/characterisation-methodology/chameo> ;
                                         <http://purl.org/dc/terms/abstract> "Nanoindentation testing ontology developed within the NanoMECommons project."@en ;
                                         <http://purl.org/dc/terms/alternative> "NanoInd" ;


### PR DESCRIPTION
Other changes:
* generate the class index from the inferred ontology
* added a resources section with links to the README file
* updated IRIs in the ttl file and added owl:versionIRI (used 1.0.0-alpha1 as version)